### PR TITLE
채팅방 목록 조회 수정

### DIFF
--- a/src/module/chat/chat.controller.ts
+++ b/src/module/chat/chat.controller.ts
@@ -28,7 +28,7 @@ import { JwtGuard } from 'src/core/guard';
 import { CurrentUser } from 'src/core/decorator';
 import { ChatService } from './chat.service';
 import { IdResponse } from 'src/shared/response';
-import { SearchedChatsResponse } from './dto/chat.response';
+import { ChatsResponse } from './dto/chat.response';
 
 @ApiTags('/chats')
 @ApiBearerAuth()
@@ -50,17 +50,17 @@ export class ChatController {
   }
 
   @ApiOperation({ summary: '채팅방 목록 조회' })
-  @ApiResponse({ status: 200, type: SearchedChatsResponse })
+  @ApiResponse({ status: 200, type: ChatsResponse })
   @Get()
   async search(
     @CurrentUser() userId: string,
-    @Query() { username, cursor, size }: GetChatsRequest,
-  ): Promise<SearchedChatsResponse> {
-    return await this.chatService.search({
+    @Query() { keyword, cursor, size }: GetChatsRequest,
+  ): Promise<ChatsResponse> {
+    return await this.chatService.getChats({
       userId,
       size: size ?? 10,
-      cursor,
-      username,
+      cursor: cursor || null,
+      keyword: keyword ?? null,
     });
   }
 

--- a/src/module/chat/chat.service.ts
+++ b/src/module/chat/chat.service.ts
@@ -40,23 +40,23 @@ export class ChatService {
     return await this.chatWriter.createChat(userId, targetUserId);
   }
 
-  async search({
+  async getChats({
     userId,
     size,
     cursor,
-    username,
+    keyword,
   }: {
     userId: string;
     size: number;
-    cursor?: string | null;
-    username?: string | null;
+    cursor: string | null;
+    keyword: string | null;
   }) {
-    const result = await this.chatReader.findManyByUsernameWithCursor(
+    const result = await this.chatReader.findManyByUsernameWithCursor({
       userId,
       size,
       cursor,
-      username,
-    );
+      name: keyword,
+    });
 
     return {
       nextCursor: result.nextCursor,
@@ -64,13 +64,11 @@ export class ChatService {
         ...chat,
         lastMessage: {
           ...chat.lastMessage,
-          image: getImageUrl(chat.lastMessage.image as string | null),
+          image: getImageUrl(chat.lastMessage.image),
         },
-        opponent: {
-          id: chat.opponent.id,
-          name: chat.opponent.name,
-          image: getImageUrl(chat.opponent.image),
-          url: chat.opponent.url,
+        opponentUser: {
+          ...chat.opponentUser,
+          image: getImageUrl(chat.opponentUser.image),
         },
       })),
     };

--- a/src/module/chat/dto/chat.request.ts
+++ b/src/module/chat/dto/chat.request.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, ArrayMinSize, IsUUID, Length } from 'class-validator';
-import { CursorRequest } from 'src/shared/request';
+import { CursorRequest } from '../../../shared/request';
+import { TrimNullableString, TrimString } from 'src/shared/request/validator';
 
 export class CreateChatRequest {
   @ApiProperty()
@@ -14,8 +15,10 @@ export class GetChatsRequest extends CursorRequest {
     description: '검색할 사용자 이름',
     example: 'user123',
   })
+  @TrimNullableString()
   @IsOptional()
-  username?: string;
+  @Length(1, 20)
+  keyword?: string;
 }
 
 export class JoinChatRequest {

--- a/src/module/chat/dto/chat.response.ts
+++ b/src/module/chat/dto/chat.response.ts
@@ -1,27 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { CursorResponse } from 'src/shared/response';
-import { UserBaseResponse } from 'src/module/user/dto';
-import { ChatMessageResponse } from './chat-message.response';
+import { CursorResponse } from '../../../shared/response';
+import { UserBaseResponse } from '../../../module/user/dto';
+import { ChatMessageBaseResponse } from './chat-message.response';
 
-export class LastChatMessageResponse {
-  @ApiProperty()
-  id: string;
-
+export class LastChatMessageResponse extends ChatMessageBaseResponse {
   @ApiProperty({
-    type: 'string',
-    nullable: true,
-    example: 'https://image.grimity.com/chat/123.webp',
+    description: '보낸 사람의 ID (마지막 채팅을 내가 보냈을수도잇음)',
   })
-  image: string | null;
-
-  @ApiProperty({ type: 'string', nullable: true })
-  content: string | null;
-
-  @ApiProperty()
-  createdAt: Date;
-
-  @ApiProperty()
-  isLike: boolean;
+  senderId: string;
 }
 
 export class ChatResponse {
@@ -32,25 +18,20 @@ export class ChatResponse {
   unreadCount: number;
 
   @ApiProperty({
-    description: '채팅방 생성 시간',
-  })
-  createdAt: Date;
-
-  @ApiProperty({
     type: UserBaseResponse,
     description: '채팅 상대의 사용자 정보',
   })
-  opponent: UserBaseResponse;
+  opponentUser: UserBaseResponse;
 
   @ApiProperty({
-    type: ChatMessageResponse,
+    type: LastChatMessageResponse,
     nullable: true,
     description: '채팅방의 마지막 메시지',
   })
-  lastMessage?: LastChatMessageResponse | null;
+  lastMessage: LastChatMessageResponse | null;
 }
 
-export class SearchedChatsResponse extends CursorResponse {
+export class ChatsResponse extends CursorResponse {
   @ApiProperty({ type: ChatResponse, isArray: true })
   chats: ChatResponse[];
 }

--- a/src/module/chat/dto/index.ts
+++ b/src/module/chat/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './chat.request';
-export * from './chat-message.request';
+export * from './chat.response';
 
+export * from './chat-message.request';
 export * from './chat-message.response';

--- a/src/module/chat/repository/chat.reader.ts
+++ b/src/module/chat/repository/chat.reader.ts
@@ -140,14 +140,14 @@ export class ChatReader {
         'User.url as opponentUrl',
       ])
       .orderBy('LastMessage.createdAt', 'desc')
-      .orderBy('LastMessage.id', 'desc')
+      .orderBy('ChatUser.chatId', 'desc')
       .$if(!!cursor, (eb) =>
         eb.where((eb) =>
           eb.or([
             eb('LastMessage.createdAt', '<', new Date(cursor!.split('_')[0])),
             eb.and([
               eb('LastMessage.createdAt', '=', new Date(cursor!.split('_')[0])),
-              eb('LastMessage.id', '<', kyselyUuid(cursor!.split('_')[1])),
+              eb('ChatUser.chatId', '<', kyselyUuid(cursor!.split('_')[1])),
             ]),
           ]),
         ),

--- a/test/e2e/chat/get-chats.e2e-spec.ts
+++ b/test/e2e/chat/get-chats.e2e-spec.ts
@@ -55,96 +55,83 @@ describe('GET /chats - 채팅 검색(커서, 이름, 사이즈)', () => {
 
     const testUserCount = 50;
 
-    for (let i = 0; i < testUserCount; i++) {
-      const testUser = await prisma.user.create({
-        data: {
-          provider: 'KAKAO',
-          providerId: `test${i}`,
-          name: `test${i}`,
-          email: `test${i}@example.com`,
-          url: `test${i}`,
-          image: `https://test${i}.com/image.png`,
-        },
-      });
+    const users = await prisma.user.createManyAndReturn({
+      data: Array.from({ length: 20 }, (_, i) => ({
+        provider: 'KAKAO',
+        providerId: `test${i}`,
+        name: `test${i}`,
+        email: `test${i}@example.com`,
+        url: `test${i}`,
+      })),
+    });
 
-      const chat = await prisma.chat.create({
-        data: { id: uuidv4(), createdAt: new Date() },
-      });
+    const chats = await prisma.chat.createManyAndReturn({
+      data: Array.from({ length: 20 }, (_, i) => ({})),
+    });
 
-      await prisma.chatUser.createMany({
-        data: [
-          {
-            userId: me.id,
-            chatId: chat.id,
-            enteredAt: new Date(),
-            unreadCount: 1,
-          },
-          {
-            userId: testUser.id,
-            chatId: chat.id,
-            enteredAt: new Date(),
-            unreadCount: 1,
-          },
-        ],
-      });
-
-      const chatMessages = [];
-      for (let j = 0; j < 50; j++) {
-        chatMessages.push({
-          chatId: chat.id,
-          userId: testUser.id,
-          content: `This is test message ${i}-${j} from testUser${i}`,
-        });
-        chatMessages.push({
-          chatId: chat.id,
+    await prisma.chatUser.createMany({
+      data: users.flatMap((user, i) => [
+        {
           userId: me.id,
-          content: `This is test message ${i}-${j} from me`,
-        });
-      }
-      await prisma.chatMessage.createMany({ data: chatMessages });
-    }
+          chatId: chats[i].id,
+          enteredAt: new Date(),
+          unreadCount: 1,
+        },
+        {
+          userId: user.id,
+          chatId: chats[i].id,
+          enteredAt: new Date(),
+          unreadCount: 1,
+        },
+      ]),
+    });
+
+    await prisma.chatMessage.createMany({
+      data: Array.from({ length: 20 }, (_, i) => ({
+        chatId: chats[i].id,
+        userId: users[i].id,
+        content: `message${i}`,
+        createdAt: new Date(Date.now() - i * 1000),
+      })),
+    });
 
     // when
-    let cursor: string | null = null;
-    while (true) {
-      const size = 5;
-      const { body, status } = await request(app.getHttpServer())
-        .get('/chats')
-        .set('Authorization', `Bearer ${accessToken}`)
-        .query({
-          username: 'test1',
-          size,
-          cursor,
-        });
+    const response1 = await request(app.getHttpServer())
+      .get('/chats')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({
+        keyword: 'test1',
+        size: 10,
+      });
 
-      cursor = body.nextCursor;
+    const response2 = await request(app.getHttpServer())
+      .get('/chats')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({
+        keyword: 'test1',
+        cursor: response1.body.nextCursor,
+      });
 
-      // then
-      expect(status).toBe(200);
-      // test1, test10 ~ test19 총 11개
-      expect(body.chats.length).toBeLessThanOrEqual(size);
-      expect(body.nextCursor).toBeDefined();
-
-      for (const [i, chat] of body.chats.entries()) {
-        expect(chat.id).toBeDefined();
-        expect(chat.opponent.id).toBeDefined();
-        expect(chat.opponent.name).toBeDefined();
-        expect(chat.opponent.image).toBeDefined();
-        expect(chat.opponent.url).toBeDefined();
-        expect(chat.lastMessage).toBeDefined();
-
-        // 마지막으로 온 채팅 메시지 순서대로 정렬되어 있는지 확인
-        if (i < body.chats.length - 1) {
-          expect(
-            new Date(chat.lastMessage.createdAt).getTime(),
-          ).toBeGreaterThan(
-            new Date(body.chats[i + 1].lastMessage.createdAt).getTime(),
-          );
-        }
-      }
-      if (!cursor) {
-        break;
-      }
-    }
+    // then
+    expect(response1.status).toBe(200);
+    expect(response1.body.chats.length).toBe(10);
+    expect(response1.body.nextCursor).toBeDefined();
+    expect(response1.body.chats[0]).toEqual({
+      id: expect.any(String),
+      unreadCount: 1,
+      opponentUser: {
+        id: expect.any(String),
+        name: 'test1',
+        image: null,
+        url: 'test1',
+      },
+      lastMessage: {
+        id: expect.any(String),
+        content: 'message1',
+        createdAt: expect.any(String),
+        image: null,
+        senderId: users[1].id,
+      },
+    });
   });
 });

--- a/test/e2e/chat/get-chats.e2e-spec.ts
+++ b/test/e2e/chat/get-chats.e2e-spec.ts
@@ -53,10 +53,10 @@ describe('GET /chats - 채팅 검색(커서, 이름, 사이즈)', () => {
     const accessToken = await register(app, 'test');
     const me = await prisma.user.findFirstOrThrow();
 
-    const testUserCount = 50;
+    const testUserCount = 20;
 
     const users = await prisma.user.createManyAndReturn({
-      data: Array.from({ length: 20 }, (_, i) => ({
+      data: Array.from({ length: testUserCount }, (_, i) => ({
         provider: 'KAKAO',
         providerId: `test${i}`,
         name: `test${i}`,
@@ -66,7 +66,7 @@ describe('GET /chats - 채팅 검색(커서, 이름, 사이즈)', () => {
     });
 
     const chats = await prisma.chat.createManyAndReturn({
-      data: Array.from({ length: 20 }, (_, i) => ({})),
+      data: Array.from({ length: testUserCount }, (_, i) => ({})),
     });
 
     await prisma.chatUser.createMany({
@@ -87,7 +87,7 @@ describe('GET /chats - 채팅 검색(커서, 이름, 사이즈)', () => {
     });
 
     await prisma.chatMessage.createMany({
-      data: Array.from({ length: 20 }, (_, i) => ({
+      data: Array.from({ length: testUserCount }, (_, i) => ({
         chatId: chats[i].id,
         userId: users[i].id,
         content: `message${i}`,
@@ -131,6 +131,28 @@ describe('GET /chats - 채팅 검색(커서, 이름, 사이즈)', () => {
         createdAt: expect.any(String),
         image: null,
         senderId: users[1].id,
+      },
+    });
+
+    expect(response2.status).toBe(200);
+    expect(response2.body.chats.length).toBe(1);
+    expect(response2.body.nextCursor).toBeNull();
+
+    expect(response2.body.chats[0]).toEqual({
+      id: expect.any(String),
+      unreadCount: 1,
+      opponentUser: {
+        id: expect.any(String),
+        name: 'test19',
+        image: null,
+        url: 'test19',
+      },
+      lastMessage: {
+        id: expect.any(String),
+        content: 'message19',
+        createdAt: expect.any(String),
+        image: null,
+        senderId: users[19].id,
       },
     });
   });


### PR DESCRIPTION
1. 기존 type unsafe한 쿼리를 type safe한 쿼리로 수정했으며 조인성능을 높였습니다.
2. 반복문으로 돌아가던 테스트코드를 bulk insert 형식으로 수정했습니다

### Query Ouput
```sql
select
  "ChatUser"."chatId" as "id",
  "ChatUser"."unreadCount",
  "LastMessage"."id" as "lastMessageId",
  "LastMessage"."content" as "lastMessageContent",
  "LastMessage"."image" as "lastMessageImage",
  "LastMessage"."createdAt" as "lastMessageCreatedAt",
  "LastMessage"."userId" as "lastMessageUserId",
  "User"."id" as "opponentId",
  "User"."name" as "opponentName",
  "User"."image" as "opponentImage",
  "User"."url" as "opponentUrl"
from
  "ChatUser"
  inner join "ChatUser" as "opponentUser" on "ChatUser"."chatId" = "opponentUser"."chatId"
  and "opponentUser"."userId" != $ 1 :: uuid
  inner join lateral (
    select
      "ChatMessage"."id",
      "ChatMessage"."userId",
      "ChatMessage"."content",
      "ChatMessage"."image",
      "ChatMessage"."createdAt"
    from
      "ChatMessage"
    where
      "ChatMessage"."chatId" = "ChatUser"."chatId"
    order by
      "ChatMessage"."createdAt" desc
    limit
      $ 2
  ) as "LastMessage" on true
  inner join "User" on "opponentUser"."userId" = "User"."id"
where
  "ChatUser"."userId" = $ 3 :: uuid
  and "ChatUser"."enteredAt" is not null
  and "User"."name" like $ 4
  and (
    "LastMessage"."createdAt" < $ 5
    or (
      "LastMessage"."createdAt" = $ 6
      and "ChatUser"."chatId" < $ 7 :: uuid
    )
  )
order by
  "LastMessage"."createdAt" desc,
  "ChatUser"."chatId" desc
limit
  $ 8
```